### PR TITLE
show talkable integration steps

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,7 @@
 
   <!-- development -->
 	<script data-main="js/main.js" src="js/vendor/requirejs/require.js"></script>
+  <script src="//d2jjzw81hqbuqv.cloudfront.net/integration/clients/plastc.min.js"></script>
 
 	<script src="//localhost:35724/livereload.js"></script>
 </body>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -159,6 +159,19 @@ define(function(require) {
 
     onConfirmation: function(data) {
       // Runs on confirmation with order data
+      this._initTalkable(data);
+    },
+
+    _initTalkable: function(data) {
+      window._talkable_purchase = {
+        order_number: data.number,
+        email: data.buyer.email,
+        subtotal: data.subtotal / 100,
+        coupon_code: data.discount_codes[0]
+      };
+
+      _talkable.registerPurchase();
+      _talkable.showPP();
     },
 
     handleError: function(err) {

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -22,3 +22,7 @@
 @import 'components/select';
 @import 'components/social_buttons';
 @import 'components/text_input';
+
+#talkable-container-pp iframe {
+  z-index: 2000000002 !important;
+}


### PR DESCRIPTION
**Plastc/Talkable Instructions**
1. add `<script src="//d2jjzw81hqbuqv.cloudfront.net/integration/clients/plastc.min.js"></script>` on the page with the checkout
2. add the Talkable code in `src/js/app.js` in the onConfirmation method
3. in your website css, you need to have this snippet:

``` css
#talkable-container-pp iframe {
  z-index: 2000000002 !important;
}
```
